### PR TITLE
Inclui verificação PSR-2 no CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 
 script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
+  - composer code-style
 
 after_script:
  - wget https://scrutinizer-ci.com/ocular.phar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,16 @@ Nós aceitamos contribuições por Pull Requests em [Github](https://github.com/
 - **Envie uma história coerente** - Certifique-se de que cada commit individual em seu pull request é significativo.
 Se você tem que fazer vários commit intermediários enquanto desenvolve, por favor faça [squash](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) dos mesmos antes de enviar.
 
-
 ## Rodando os Testes
 
 ``` bash
 composer test
 ```
 
+## Verificando o estilo do código
+
+``` bash
+composer code-style
+```
 
 **Feliz desenvolvimento!**

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",
-        "scrutinizer/ocular": "~1.1"
+        "scrutinizer/ocular": "~1.1",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "autoload": {
         "psr-4": {
@@ -34,7 +35,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "code-style": "./vendor/bin/phpcs --standard=PSR2 src/"
     },
     "extra": {
         "branch-alias": {

--- a/src/ApiRequester.php
+++ b/src/ApiRequester.php
@@ -82,8 +82,9 @@ class ApiRequester
      */
     private function checkRateLimit(ResponseInterface $response)
     {
-        if (429 === $response->getStatusCode())
+        if (429 === $response->getStatusCode()) {
             throw new RateLimitException($response);
+        }
 
         return $this;
     }

--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -47,8 +47,9 @@ class RequestException extends Exception
 
         foreach ($errors as $error) {
             $this->ids[] = $error->id;
-            if(isset($error->parameter))
+            if (isset($error->parameter)) {
                 $this->parameters[] = $error->parameter;
+            }
             $this->messages[] = $error->message;
         }
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -140,7 +140,8 @@ abstract class Resource
      *
      * @return mixed
      */
-    public function getLastResponse(){
-       return $this->apiRequester->lastResponse;
+    public function getLastResponse()
+    {
+        return $this->apiRequester->lastResponse;
     }
 }


### PR DESCRIPTION
Percebi que embora exijamos que o código dos PRs sigam a PSR-2, nós não testamos isso no CI.

O objetivo desse PR é adicionar a verificação do estilo no fluxo do CI para garantirmos a consistência do código no repositório