### PR TITLE
Colocar na documentação como setar para sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ switch ($event->type) {
 }
 ```
 
+### Configurar SANDBOX
+
+Caso você precise utilizar o sistema em ambiente sandbox, basta apenas inserir essa variável de ambiente setando para nossos servidores:
+```
+putenv('VINDI_API_KEY=https://sandbox-app.vindi.com.br/api/v1/');
+```
+
+
 ## Dúvidas
 Caso necessite de informações sobre a plataforma ou API, por favor acesse o [Atendimento Vindi](http://atendimento.vindi.com.br/hc/pt-br).
 


### PR DESCRIPTION
Vi que ultimamente fizeram um commit no arquivo src/vindi.php atualizando a APIBASE para utilizar a variavel de ambiente.
Estou fazendo a proposta de apenas adicionar na documentação a possibilidade do desenvolvedor ver que dá pra colocar em sandbox através da variável.
Lembrem de atualizar o composer, está numa versão diferente da do github