### PR TITLE
Adiciona método retry ao recurso de Invoice

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -13,4 +13,16 @@ class Invoice extends Resource
     {
         return 'invoices';
     }
+
+    /**
+     *  Make a POST request to invoices/{id}/retry
+     *
+     * @param  int $id The resource's id.
+     *
+     * @return mixed
+     */
+    public function retry($id)
+    {
+        return $this->post($id, 'retry');
+    }
 }

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Vindi\Test;
 
+use stdClass;
 use Vindi\ApiRequester;
 use Vindi\Invoice;
 
@@ -17,5 +18,17 @@ class InvoiceTest extends ResourceTest
     public function it_should_have_an_endpoint()
     {
         $this->assertSame($this->resource->endpoint(), 'invoices');
+    }
+
+    /** @test */
+    public function it_should_retry_an_invoice()
+    {
+        $stdClass = new stdClass;
+
+        $this->resource->apiRequester->method('request')->willReturn($stdClass);
+
+        $response = $this->resource->retry(1);
+
+        $this->assertSame($response, $stdClass);
     }
 }


### PR DESCRIPTION
Precisei implementar o recurso de Invoice no sistema de billing da empresa em que trabalho, contudo não encontrei o método retry, descrito na documentação (https://vindi.github.io/api-docs/dist/#!/invoices/POST_version_invoices_id_retry_format). Esse PR é pra adicionar tal método ao recurso. 