### PR TITLE
Feature/modifica construtor resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 composer.lock
 vendor
-.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Todas as mudanças notáveis serão documentadas neste arquivo.
 
+## 1.1.0 - 04/05/2018
+- Option to input VINDI_API_URI passing as arguments on the instances.
+- Option to input VINDI_API_KEY passing as arguments on the instances.
+
 ## 1.0.11 - 14/03/2018
 - VINDI_API_URI environment variable support.
 - Add invoice retry endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 Todas as mudanças notáveis serão documentadas neste arquivo.
 
 ## 1.1.0 - 04/05/2018
-- Option to input VINDI_API_URI passing as arguments on the instances.
-- Option to input VINDI_API_KEY passing as arguments on the instances.
+- Option to pass VINDI_API_URI as an argument on instance son of Resource.
+- Option to pass VINDI_API_KEY as an argument on instance son of Resource.
 
 ## 1.0.11 - 14/03/2018
 - VINDI_API_URI environment variable support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Todas as mudanças notáveis serão documentadas neste arquivo.
+All notable changes will be documented in this file.
 
 ## 1.1.0 - 04/05/2018
 - Option to pass VINDI_API_URI as an argument on instance son of Resource.

--- a/README.md
+++ b/README.md
@@ -74,16 +74,14 @@ foreach ($customers as $customer) {
 ```php
 require __DIR__.'/vendor/autoload.php';
 
-// Instancia o serviço de Customers (Clientes)
+// Declara em um array os valores de VINDI_API_KEY e VINDI_API_URI
 $arguments = array(
     \Vindi\Vindi::VINDI_API_KEY => 'SUA_CHAVE_DA_API',
     \Vindi\Vindi::VINDI_API_URI => 'https://sandbox-app.vindi.com.br/api/v1/'
 );
 
+// Instancia o serviço de Customers (Clientes) com o array contendo VINDI_API_KEY e VINDI_API_URI
 $customerService = new Vindi\Customer($arguments);
-
-// Essa instância não requer argumentos
-$planService = new Vindi\Plan;
 
 // Cria um novo cliente:
 $customer = $customerService->create([
@@ -107,6 +105,20 @@ foreach ($customers as $customer) {
 
     echo "O cliente '{$customer->name}' foi atualizado!<br />";
 }
+
+// Instancia o serviço de Products que não requer argumentos, pois já foi configurado em Customer
+$productService = new Vindi\Product;
+
+// Cria um novo produto:
+$product = $productService->create([
+    'name' => 'Teste de Produto',
+    'pricing_schema' => [
+        'price' => 150,
+        'schema_type' => 'flat',
+    ]
+]);
+
+echo "Novo produto criado com o id  '{$product->id}'.<br />";
 ```
 
 Para mais detalhes sobre quais serviços existem, quais campos enviar e demais informações,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![alt text align:center](https://www.vindi.com.br/assets/images/logo-footer.png "Vindi")
+![alt text align:center](https://vindi-blog.s3.amazonaws.com/wp-content/uploads/2017/10/logo-vindi-1.png "Vindi")
 
 # Vindi - SDK PHP
 
@@ -30,26 +30,60 @@ composer require vindi/vindi-php
 ``` bash
 composer test
 ```
+### Exemplo de Autenticação #1
 
-### Exemplo
+> Esse método de autenticação utiliza-se de variáveis de ambiente.
 
 ```php
 require __DIR__.'/vendor/autoload.php';
 
-// Coloca a chave da Vindi (VINDI_API_KEY) no environment do PHP.
+// Coloca a chave da Vindi (VINDI_API_KEY) na variável de ambiente do PHP.
 putenv('VINDI_API_KEY=SUA_CHAVE_DA_API');
 
 // Instancia o serviço de Customers (Clientes)
 $customerService = new Vindi\Customer;
 
-OU
+// Cria um novo cliente:
+$customer = $customerService->create([
+    'name'  => 'Teste da Silva',
+    'email' => 'contato@vindi.com.br',
+]);
+
+echo "Novo cliente criado com o id '{$customer->id}'.<br />";
+
+// Busca todos os clientes, ordenando pelo campo 'created_at' descendente.
+$customers = $customerService->all([
+    'sort_by'    => 'created_at',
+    'sort_order' => 'desc'
+]);
+
+// Para cada cliente da array de clientes
+foreach ($customers as $customer) {
+    $customerService->update($customer->id, [
+        'notes' => 'Este cliente foi atualizado pelo SDK PHP.',
+    ]);
+
+    echo "O cliente '{$customer->name}' foi atualizado!<br />";
+}
+```
+
+### Exemplo de Autenticação #2
+
+> Esse método de autenticação utiliza-se de inserção de um *array* como argumento na primeira instância de uma classe *filha* de Resource, sendo ignorada uma nova tentativa de inserir o argumento em uma outra instância. 
+
+```php
+require __DIR__.'/vendor/autoload.php';
 
 // Instancia o serviço de Customers (Clientes)
 $arguments = array(
-    'VINDI_API_KEY' => 'SUA_CHAVE_DA_API',
-    'VINDI_API_URI' => 'https://sandbox-app.vindi.com.br/api/v1/'
+    \Vindi\Vindi::VINDI_API_KEY => 'SUA_CHAVE_DA_API',
+    \Vindi\Vindi::VINDI_API_URI => 'https://sandbox-app.vindi.com.br/api/v1/'
 );
+
 $customerService = new Vindi\Customer($arguments);
+
+// Essa instância não requer argumentos
+$planService = new Vindi\Plan;
 
 // Cria um novo cliente:
 $customer = $customerService->create([

--- a/README.md
+++ b/README.md
@@ -25,16 +25,14 @@ Via Composer
 composer require vindi/vindi-php
 ```
 
-### Teste
+# Métodos de Autenticação
 
-``` bash
-composer test
-```
-### Exemplo de Autenticação #1
+## Variável de ambiente
 
-> Esse método de autenticação utiliza-se de variáveis de ambiente.
+> Esse método de autenticação utiliza-se de inserção de variáveis de ambiente podendo ser utilizado um arquivo *.env* para guardar dados de configuração.   
 
 ```php
+
 require __DIR__.'/vendor/autoload.php';
 
 // Coloca a chave da Vindi (VINDI_API_KEY) na variável de ambiente do PHP.
@@ -45,36 +43,14 @@ putenv('VINDI_API_URI=https://sandbox-app.vindi.com.br/api/v1/');
 
 // Instancia o serviço de Customers (Clientes)
 $customerService = new Vindi\Customer;
-
-// Cria um novo cliente:
-$customer = $customerService->create([
-    'name'  => 'Teste da Silva',
-    'email' => 'contato@vindi.com.br',
-]);
-
-echo "Novo cliente criado com o id '{$customer->id}'.<br />";
-
-// Busca todos os clientes, ordenando pelo campo 'created_at' descendente.
-$customers = $customerService->all([
-    'sort_by'    => 'created_at',
-    'sort_order' => 'desc'
-]);
-
-// Para cada cliente da array de clientes
-foreach ($customers as $customer) {
-    $customerService->update($customer->id, [
-        'notes' => 'Este cliente foi atualizado pelo SDK PHP.',
-    ]);
-
-    echo "O cliente '{$customer->name}' foi atualizado!<br />";
-}
 ```
 
-### Exemplo de Autenticação #2
+## Argumento de instância
 
 > Esse método de autenticação utiliza-se de inserção de um *array* como argumento na primeira instância de uma classe *filha* de Resource, **sendo ignorada uma nova tentativa de inserir o argumento em uma outra instância.**  
 
 ```php
+
 require __DIR__.'/vendor/autoload.php';
 
 // Declara em um array os valores de VINDI_API_KEY e VINDI_API_URI
@@ -86,6 +62,14 @@ $arguments = array(
 // Instancia o serviço de Customers (Clientes) com o array contendo VINDI_API_KEY e VINDI_API_URI
 $customerService = new Vindi\Customer($arguments);
 
+```
+
+## Exemplo de implementação
+
+> Exemplo de código após autenticação (uma das duas formas existentes descritas acima), seguindo a sequência de instanciação de Customer.
+
+```php
+
 // Cria um novo cliente:
 $customer = $customerService->create([
     'name'  => 'Teste da Silva',
@@ -109,7 +93,7 @@ foreach ($customers as $customer) {
     echo "O cliente '{$customer->name}' foi atualizado!<br />";
 }
 
-// Instancia o serviço de Products que não requer argumentos, pois já foi configurado em Customer
+// Instancia o serviço de Product que não requer argumentos, pois já foi configurado em Customer ou foi configurado nas variáveis de ambiente.
 $productService = new Vindi\Product;
 
 // Cria um novo produto:
@@ -144,7 +128,7 @@ $lastResponse->getHeaders();
 $lastResponse->getHeader('Header-Name');
 ```
 
-### Webhooks
+## Webhooks
 
 Este pacote torna possível a interpretação dos [webhooks enviados pela Vindi][link-webhooks].
 Para tal, disponibilize uma URL/rota que será acessível pela web e nela utilize a classe `Vindi\WebhookHandler`

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ require __DIR__.'/vendor/autoload.php';
 
 // Declara em um array os valores de VINDI_API_KEY e VINDI_API_URI
 $arguments = array(
-    \Vindi\Vindi::VINDI_API_KEY => 'SUA_CHAVE_DA_API',
-    \Vindi\Vindi::VINDI_API_URI => 'https://sandbox-app.vindi.com.br/api/v1/'
+    'VINDI_API_KEY' => 'SUA_CHAVE_DA_API',
+    'VINDI_API_URI' => 'https://sandbox-app.vindi.com.br/api/v1/'
 );
 
 // Instancia o serviço de Customers (Clientes) com o array contendo VINDI_API_KEY e VINDI_API_URI

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ composer require vindi/vindi-php
 
 ## Variável de ambiente
 
-> Esse método de autenticação utiliza-se de inserção de variáveis de ambiente podendo ser utilizado um arquivo *.env* para guardar dados de configuração.   
+> Esse método de autenticação utiliza-se de inserção de variáveis de ambiente.   
 
 ```php
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ foreach ($customers as $customer) {
 
 ### Exemplo de Autenticação #2
 
-> Esse método de autenticação utiliza-se de inserção de um *array* como argumento na primeira instância de uma classe *filha* de Resource, sendo ignorada uma nova tentativa de inserir o argumento em uma outra instância. 
+> Esse método de autenticação utiliza-se de inserção de um *array* como argumento na primeira instância de uma classe *filha* de Resource, **sendo ignorada uma nova tentativa de inserir o argumento em uma outra instância.**  
 
 ```php
 require __DIR__.'/vendor/autoload.php';

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![alt text align:center](https://www.vindi.com.br/image/vindi-logo-transparente.png "Vindi")
+![alt text align:center](https://www.vindi.com.br/assets/images/logo-footer.png "Vindi")
 
 # Vindi - SDK PHP
 
@@ -41,6 +41,15 @@ putenv('VINDI_API_KEY=SUA_CHAVE_DA_API');
 
 // Instancia o serviço de Customers (Clientes)
 $customerService = new Vindi\Customer;
+
+OU
+
+// Instancia o serviço de Customers (Clientes)
+$arguments = array(
+    'VINDI_API_KEY' => 'SUA_CHAVE_DA_API',
+    'VINDI_API_URI' => 'https://sandbox-app.vindi.com.br/api/v1/'
+);
+$customerService = new Vindi\Customer($arguments);
 
 // Cria um novo cliente:
 $customer = $customerService->create([

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ require __DIR__.'/vendor/autoload.php';
 // Coloca a chave da Vindi (VINDI_API_KEY) na variável de ambiente do PHP.
 putenv('VINDI_API_KEY=SUA_CHAVE_DA_API');
 
+// Coloca a chave da Vindi (VINDI_API_URI) na variável de ambiente do PHP.
+putenv('VINDI_API_URI=https://sandbox-app.vindi.com.br/api/v1/');
+
 // Instancia o serviço de Customers (Clientes)
 $customerService = new Vindi\Customer;
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -11,9 +11,18 @@ abstract class Resource
 
     /**
      * Resource constructor.
+     *
+     * @param array $arguments
      */
-    public function __construct()
+    public function __construct($arguments = [])
     {
+        if (key_exists('VINDI_API_KEY', $arguments)) {
+            Vindi::setApiKey($arguments['VINDI_API_KEY']);
+        }
+
+        if (key_exists('VINDI_API_URI', $arguments)) {
+            Vindi::setApiUri($arguments['VINDI_API_URI']);
+        }
         $this->apiRequester = new ApiRequester;
     }
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -16,12 +16,12 @@ abstract class Resource
      */
     public function __construct($arguments = [])
     {
-        if (key_exists('VINDI_API_KEY', $arguments)) {
-            Vindi::setApiKey($arguments['VINDI_API_KEY']);
+        if (key_exists(Vindi::VINDI_API_KEY, $arguments)) {
+            Vindi::setApiKey($arguments[Vindi::VINDI_API_KEY]);
         }
 
-        if (key_exists('VINDI_API_URI', $arguments)) {
-            Vindi::setApiUri($arguments['VINDI_API_URI']);
+        if (key_exists(Vindi::VINDI_API_URI, $arguments)) {
+            Vindi::setApiUri($arguments[Vindi::VINDI_API_URI]);
         }
         $this->apiRequester = new ApiRequester;
     }

--- a/src/Vindi.php
+++ b/src/Vindi.php
@@ -4,6 +4,19 @@ namespace Vindi;
 
 class Vindi
 {
+    /**
+     * The Environment variable name or argument for API URI.
+     *
+     * @var string
+     */
+    const VINDI_API_URI = 'VINDI_API_URI';
+
+    /**
+     * The Environment variable name or argument for API Key.
+     *
+     * @var string
+     */
+    const VINDI_API_KEY = 'VINDI_API_KEY';
 
     /**
      * API KEY to be set on instances
@@ -14,7 +27,7 @@ class Vindi
 
     /**
      * URI to be set on instances
-     * Ex.: 'https://sandbox-app.vindi.com.br/api/v1/'
+     * Ex.: https://sandbox-app.vindi.com.br/api/v1/
      *
      * @var string;
      */
@@ -26,20 +39,6 @@ class Vindi
      * @var string
      */
     public static $sdkVersion = '1.1.0';
-
-    /**
-     * The Environment variable name for API URI.
-     *
-     * @var string
-     */
-    public static $apiUriEnvVar = 'VINDI_API_URI';
-
-    /**
-     * The Environment variable name for API Key.
-     *
-     * @var string
-     */
-    public static $apiKeyEnvVar = 'VINDI_API_KEY';
 
     /**
      * The Environment variable name for API Time Out.
@@ -86,8 +85,8 @@ class Vindi
      */
     public static function getApiUri()
     {
-        if (!empty(getenv(static::$apiUriEnvVar))) {
-            return getenv(static::$apiUriEnvVar);
+        if (!empty(getenv(static::VINDI_API_URI))) {
+            return getenv(static::VINDI_API_URI);
         }
 
         if (null !== self::$vindi_api_uri) {
@@ -108,7 +107,7 @@ class Vindi
             return self::$vindi_api_key;
         }
 
-        return getenv(static::$apiKeyEnvVar);
+        return getenv(static::VINDI_API_KEY);
     }
 
     /**

--- a/src/Vindi.php
+++ b/src/Vindi.php
@@ -118,10 +118,10 @@ class Vindi
      */
     public static function getApiTimeOut()
     {
-        if (!empty(getenv(static::$apiTimeOutEnvVar))) {
-            return getenv(static::$apiTimeOutEnvVar);
+        if (empty(getenv(static::$apiTimeOutEnvVar))) {
+            return 60;
         }
-        return 60;
+        return getenv(static::$apiTimeOutEnvVar);
     }
 
     /**

--- a/src/Vindi.php
+++ b/src/Vindi.php
@@ -85,12 +85,12 @@ class Vindi
      */
     public static function getApiUri()
     {
-        if (!empty(getenv(static::VINDI_API_URI))) {
-            return getenv(static::VINDI_API_URI);
-        }
-
         if (null !== self::$vindi_api_uri) {
             return self::$vindi_api_uri;
+        }
+
+        if (!empty(getenv(static::VINDI_API_URI))) {
+            return getenv(static::VINDI_API_URI);
         }
 
         return 'https://app.vindi.com.br/api/v1/';

--- a/src/Vindi.php
+++ b/src/Vindi.php
@@ -6,6 +6,21 @@ class Vindi
 {
 
     /**
+     * API KEY to be set on instances
+     *
+     * @var string
+     */
+    private static $vindi_api_key;
+
+    /**
+     * URI to be set on instances
+     * Ex.: 'https://sandbox-app.vindi.com.br/api/v1/'
+     *
+     * @var string;
+     */
+    private static $vindi_api_uri;
+
+    /**
      * This Package SDK Version.
      *
      * @var string
@@ -34,16 +49,52 @@ class Vindi
     public static $apiTimeOutEnvVar = 'VINDI_API_TIME_OUT';
 
     /**
+     * Vindi constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Set API KEY
+     *
+     * @param $vindi_api_key
+     */
+    public static function setApiKey($vindi_api_key)
+    {
+        if (null === self::$vindi_api_key) {
+            self::$vindi_api_key = $vindi_api_key;
+        }
+    }
+
+    /**
+     * Set API URI
+     *
+     * @param $vindi_api_uri
+     */
+    public static function setApiUri($vindi_api_uri)
+    {
+        if (null === self::$vindi_api_uri) {
+            self::$vindi_api_uri = $vindi_api_uri;
+        }
+    }
+
+    /**
      * Get Vindi API URI from environment.
      *
      * @return string
      */
     public static function getApiUri()
     {
-        if (empty(getenv(static::$apiUriEnvVar))) {
-            return 'https://app.vindi.com.br/api/v1/';
+        if (!empty(getenv(static::$apiUriEnvVar))) {
+            return getenv(static::$apiUriEnvVar);
         }
-        return getenv(static::$apiUriEnvVar);
+
+        if (null !== self::$vindi_api_uri) {
+            return self::$vindi_api_uri;
+        }
+
+        return 'https://app.vindi.com.br/api/v1/';
     }
 
     /**
@@ -53,6 +104,10 @@ class Vindi
      */
     public static function getApiKey()
     {
+        if (null !== self::$vindi_api_key) {
+            return self::$vindi_api_key;
+        }
+
         return getenv(static::$apiKeyEnvVar);
     }
 
@@ -63,10 +118,10 @@ class Vindi
      */
     public static function getApiTimeOut()
     {
-        if (empty(getenv(static::$apiTimeOutEnvVar))) {
-            return 60;
+        if (!empty(getenv(static::$apiTimeOutEnvVar))) {
+            return getenv(static::$apiTimeOutEnvVar);
         }
-        return getenv(static::$apiTimeOutEnvVar);
+        return 60;
     }
 
     /**

--- a/src/Vindi.php
+++ b/src/Vindi.php
@@ -25,7 +25,7 @@ class Vindi
      *
      * @var string
      */
-    public static $sdkVersion = '1.0.11';
+    public static $sdkVersion = '1.1.0';
 
     /**
      * The Environment variable name for API URI.

--- a/tests/VindiTest.php
+++ b/tests/VindiTest.php
@@ -22,7 +22,7 @@ class VindiTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_get_api_uri_from_environment()
     {
-        putenv(Vindi::$apiUriEnvVar);
+        putenv(Vindi::VINDI_API_URI);
         $uri = Vindi::getApiUri();
         $this->assertEquals($uri, 'https://app.vindi.com.br/api/v1/');
 
@@ -32,7 +32,7 @@ class VindiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($uri, $random);
 
         $random = rand();
-        putenv(Vindi::$apiUriEnvVar . '=' . $random);
+        putenv(Vindi::VINDI_API_URI . '=' . $random);
         $uri = Vindi::getApiUri();
         $this->assertEquals($uri, $random);
     }
@@ -40,12 +40,12 @@ class VindiTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_get_api_key_from_environment()
     {
-        putenv(Vindi::$apiKeyEnvVar);
+        putenv(Vindi::VINDI_API_KEY);
         $key = Vindi::getApiKey();
         $this->assertFalse($key);
 
         $random = rand();
-        putenv(Vindi::$apiKeyEnvVar . '=' . $random);
+        putenv(Vindi::VINDI_API_KEY . '=' . $random);
         $key = Vindi::getApiKey();
         $this->assertEquals($key, $random);
 

--- a/tests/VindiTest.php
+++ b/tests/VindiTest.php
@@ -27,12 +27,12 @@ class VindiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($uri, 'https://app.vindi.com.br/api/v1/');
 
         $random = rand();
-        Vindi::setApiUri($random);
+        putenv(Vindi::VINDI_API_URI . '=' . $random);
         $uri = Vindi::getApiUri();
         $this->assertEquals($uri, $random);
 
         $random = rand();
-        putenv(Vindi::VINDI_API_URI . '=' . $random);
+        Vindi::setApiUri($random);
         $uri = Vindi::getApiUri();
         $this->assertEquals($uri, $random);
     }

--- a/tests/VindiTest.php
+++ b/tests/VindiTest.php
@@ -6,37 +6,71 @@ use Vindi\Vindi;
 
 class VindiTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var \Vindi\Vindi;
-     */
-    private $vindi;
 
-    public function setUp()
+    /** @test */
+    public function it_should_bet_private()
     {
-        $this->vindi = new Vindi;
+        try {
+            $constructor = new \ReflectionClass(Vindi::class);
+            $modifier = \Reflection::getModifierNames($constructor->getModifiers());
+            $this->assertEquals('private',$modifier[0]);
+        } catch (\Exception $exception) {
+            echo $exception->getMessage();
+        }
     }
 
-    public function tearDown()
+    /** @test */
+    public function it_should_get_api_uri_from_environment()
     {
-        $this->vindi = null;
+        putenv(Vindi::$apiUriEnvVar);
+        $uri = Vindi::getApiUri();
+        $this->assertEquals($uri, 'https://app.vindi.com.br/api/v1/');
+
+        $random = rand();
+        Vindi::setApiUri($random);
+        $uri = Vindi::getApiUri();
+        $this->assertEquals($uri, $random);
+
+        $random = rand();
+        putenv(Vindi::$apiUriEnvVar . '=' . $random);
+        $uri = Vindi::getApiUri();
+        $this->assertEquals($uri, $random);
     }
 
     /** @test */
     public function it_should_get_api_key_from_environment()
     {
         putenv(Vindi::$apiKeyEnvVar);
-        $key = $this->vindi->getApiKey();
+        $key = Vindi::getApiKey();
         $this->assertFalse($key);
 
         $random = rand();
         putenv(Vindi::$apiKeyEnvVar . '=' . $random);
-        $key = $this->vindi->getApiKey();
+        $key = Vindi::getApiKey();
         $this->assertEquals($key, $random);
+
+        $random = rand();
+        Vindi::setApiKey($random);
+        $uri = Vindi::getApiKey();
+        $this->assertEquals($uri, $random);
+
+    }
+
+    /** @test */
+    public function it_should_get_api_time_out()
+    {
+        $time = Vindi::getApiTimeOut();
+        $this->assertEquals($time, 60);
+
+        $random = rand();
+        putenv(Vindi::$apiTimeOutEnvVar . '=' . $random);
+        $time = Vindi::getApiTimeOut();
+        $this->assertEquals($time, $random);
     }
 
     /** @test */
     public function cert_file_should_exists()
     {
-        $this->assertFileExists($this->vindi->getCertPath());
+        $this->assertFileExists(Vindi::getCertPath());
     }
 }


### PR DESCRIPTION
## Motivação
Atendendo a dois issues apresentados pelo github de usuários do SDK-PHP foi criado a opção de passar VINDI_API_URI e VINDI_API_KEY como argumentos na primeira instância de uma classe filha de Resource, sendo ignorada na tentativa de reinserção em uma nova instância.

## Solução proposta
Implementação da feature que atendesse a expectativa dos usuários de não só depender de variáveis de ambiente para configurar VINDI_API_URI e VINDI_API_KEY e refatoração do código para que ficasse coeso com a solução.
