### PR TITLE
Ajuste no parse das respostas da API

### DIFF
--- a/src/ApiRequester.php
+++ b/src/ApiRequester.php
@@ -75,8 +75,12 @@ class ApiRequester
         $content = $response->getBody()->getContents();
 
         $decoded = json_decode($content); // parse as object
-        reset($decoded);
-        $data = current($decoded); // get first attribute from array, e.g.: subscription, subscriptions, errors.
+        $data = $decoded;
+
+        if (!empty($decoded)) {
+            reset($decoded);
+            $data = current($decoded); // get first attribute from array, e.g.: subscription, subscriptions, errors.
+        }
 
         $this->checkRateLimit($response)
             ->checkForErrors($response, $data);

--- a/tests/ApiRequesterTest.php
+++ b/tests/ApiRequesterTest.php
@@ -11,6 +11,7 @@ use Vindi\Exceptions\RequestException;
 use Vindi\Exceptions\ValidationException;
 use Vindi\Http\Client;
 use Vindi\ApiRequester;
+use function GuzzleHttp\json_encode;
 
 class ApiRequesterTest extends \PHPUnit_Framework_TestCase
 {
@@ -89,4 +90,31 @@ class ApiRequesterTest extends \PHPUnit_Framework_TestCase
 
         $this->apiRequester->request('GET', 'test');
     }
+
+     /** @test */
+     public function it_should_pass_when_response_has_a_not_empty_body()
+     {
+         $request = new Request('GET', 'test');
+
+         # json_encode(["test"]) replicates a fake json response received from Vindi' API
+         $response = new Response(200, [], json_encode(["text"]));
+         $clientException = new ClientException('', $request, $response);
+
+         $this->apiRequester->client->method('request')->willThrowException($clientException);
+         $this->assertTrue(!empty($this->apiRequester->request('GET', 'test')));
+     }
+
+     /** @test */
+     public function it_should_pass_when_response_has_a_empty_body()
+     {
+         $request = new Request('GET', 'test');
+
+         # json_encode(null) replicates the ApiRequester@response method behavior when received a null response for some unmapped reason
+         $response = new Response(200, [], json_decode(null));
+
+         $clientException = new ClientException('', $request, $response);
+
+         $this->apiRequester->client->method('request')->willThrowException($clientException);
+         $this->assertTrue(empty($this->apiRequester->request('GET', 'test')));
+     }
 }


### PR DESCRIPTION
## Motivação
Ajuste no parse das respostas da API, em alguns casos, provavelmente de falhas de conexao, a resposta do body fica vazia e o processo de json_decode nao funciona, ocorrendo exception quando o metodo response ApiRequest tenta resetar os ponteiros do array.

A aplicação da verificação de resposta nula evita exceptions que interferem no processo de tratamento de erros na integração com a API. Por exemplo, se isso acontece e a exception é gerada, a integração não é capaz de tratar fora do SDK, com o tratamento a resposta é retornada mesmo que vazia.

## Solução Proposta
Adicionei a verificacao com o metodo empty() para que nestes casos a excecao seja evitada. Estendi a classe de teste, ApiRequestTest, para cobrir os casos de response null com json_decode para respostas nulas e com strings json validas
