### PR TITLE
Adiciona parâmetro que permite estornar uma cobrança parcialmente

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes will be documented in this file.
 
+## 1.2.1 - 10/05/2019
+- Add the required parameter for partial refund
+
 ## 1.2.0 - 28/05/2018
 - Add new endpoints to keep up with Vindi API.
 - Notification

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -54,16 +54,17 @@ class Charge extends Resource
     /**
      * Make a POST request to charges/{id}/refund.
      *
-     * @param int $id The resource's id.
+     * @param int   $id             The resource's id.
+     * @param array $form_params    The request body.
      *
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Vindi\Exceptions\RateLimitException
      * @throws \Vindi\Exceptions\RequestException
      */
-    public function refund($id)
+    public function refund($id,$form_params = [])
     {
-        return $this->post($id, 'refund');
+        return $this->post($id, 'refund', $form_params);
     }
 
     /**

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -62,7 +62,7 @@ class Charge extends Resource
      * @throws \Vindi\Exceptions\RateLimitException
      * @throws \Vindi\Exceptions\RequestException
      */
-    public function refund($id,$form_params = [])
+    public function refund($id, array $form_params = [])
     {
         return $this->post($id, 'refund', $form_params);
     }

--- a/src/Vindi.php
+++ b/src/Vindi.php
@@ -43,7 +43,7 @@ class Vindi
      *
      * @var string
      */
-    public static $sdkVersion = '1.2.0';
+    public static $sdkVersion = '1.2.1';
 
     /**
      * The Environment variable name for API Time Out.


### PR DESCRIPTION
## Motivação
Ao desenvolver uma aplicação, precisei estornar parcialmente uma fatura e cancelar a fatura automaticamente. Ao analisar a API, notei que esses parâmetros são passados no body da requisição, porém o SDK PHP não possui esta opção.

## Solução Proposta
Adicionar parâmetro $form_params na função que estorna a cobrança
Parâmetro necessário para estornar uma fatura parcialmente ou totalmente, adicionar comentário sobre o estorno e permitir cancelar a fatura ao estornar a cobrança.

Parâmetros que são permitidos utilizar no body da requisição.
```
{
  "amount": 0,
  "cancel_bill": false,
  "comments": ""
}
```
