### PR TITLE
Remove testes com PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
 
 matrix:
   include:
-    - php: 5.5
-      env: COLLECT_COVERAGE=true
     - php: 5.6
       env: COLLECT_COVERAGE=true
     - php: 7.0


### PR DESCRIPTION
## Motivação
Um dos nossos requisitos é a utilização do PHP em versões igual ou posteriores a **5.6**; Porém, nossos testes estão sendo executados também em versões **5.5**, o que gera alguns conflitos e impede o sucesso da build.
## Solução proposta
Remover os testes da versão **5.5** por não serem suportadas.