### PR TITLE
Melhora endpoint de charges

### DIFF
--- a/src/Charge.php
+++ b/src/Charge.php
@@ -2,11 +2,11 @@
 
 namespace Vindi;
 
-/**
- * Class Charge
- *
- * @package Vindi
- */
+    /**
+     * Class Charge
+     *
+     * @package Vindi
+     */
 class Charge extends Resource
 {
     /**

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -94,6 +94,6 @@ class Charge extends Resource
       */
     public function capture($id)
     {
-      return $this->post($id, 'capture');
+        return $this->post($id, 'capture');
     }
 }

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -77,8 +77,23 @@ class Charge extends Resource
      * @throws \Vindi\Exceptions\RateLimitException
      * @throws \Vindi\Exceptions\RequestException
      */
-    public function fraudReview($id)
+    public function fraudReview($id, array $form_params = [])
     {
-        return $this->post($id, 'fraud_review');
+        return $this->post($id, 'fraud_review', $form_params);
+    }
+
+    /**
+      * Make a POST request to charges/{id}/capture.
+      *
+      * @param int $id The resource's id.
+      *
+      * @return mixed
+      * @throws \GuzzleHttp\Exception\GuzzleException
+      * @throws \Vindi\Exceptions\RateLimitException
+      * @throws \Vindi\Exceptions\RequestException
+      */
+    public function capture($id)
+    {
+      return $this->post($id, 'capture');
     }
 }

--- a/tests/ChargeTest.php
+++ b/tests/ChargeTest.php
@@ -55,4 +55,13 @@ class ChargeTest extends ResourceTest
         $response = $this->resource->fraudReview(1, []);
         $this->assertSame($response, $stdClass);
     }
+
+    /** @test */
+    public function it_should_capture_a_charge()
+    {
+      $stdClass = new stdClass;
+      $this->resource->apiRequester->method('request')->willReturn($stdClass);
+      $response = $this->resource->capture(1, []);
+      $this->assertSame($response, $stdClass);
+    }
 }


### PR DESCRIPTION
## Motivação

### Fraud review
Utilizando a SDK, verifiquei que a endpoint `charges/{id}/fraud_review` não funcionava corretamente, pois no seu arquivo ele esperava apenas ID. A endpoint espera, além de ID, parâmetros obrigatórios.

### Capture
Também verifiquei que a SDK não possui uma chamada para a endpoint `charges/{id}/capture` (essa sim, espera somente ID.

## Solução Proposta
Corrigi a chamada para a endpoint de revisão de cobranças no status suspeita de fraude e adicionei a endpoint para capturar transações autorizadas.

## Como testar
A fim de confirmar que o comportamento de ambos estava ok, realizei dois simples testes.

Para a endpoint `charges/{id}/fraud_review`:

1. Instalei a Konduto no meu ambiente de testes;
2. Configurei-a para sempre deixar as cobranças no status suspeita de fraude;
3. Efetuei uma chamada para gerar uma fatura avulsa e, posteriormente, para revisar a suspeita:

```php
$review = $chargeService->fraud_review($charge->id,
[
  'fraud_review_action' => 'approve'
]);

echo "{$charge->status}".PHP_EOL;
```

Assim, no `echo` ele retorna o novo status da cobrança - `paid`.

---

Para a endpoint `charges/{id}/capture`:

1. Configurei meu gateway para duas etapas - autorização e captura manual;
2. Ao gerar outra fatura avulsa, recuperei o ID da cobrança e fiz a chamada para capturar a transação:

```php
$capture = $chargeService->capture($charge->id);
```

Pessoal, tenho só a agradecer pelas dicas/feedbacks! Vou seguir efetuando correções e melhorias. :heart: