### PR TITLE
Adiciona endpoint para lotes de exportação

### DIFF
--- a/src/ExportBatch.php
+++ b/src/ExportBatch.php
@@ -34,4 +34,3 @@ class ExportBatch extends Resource
         return $this->post($id, 'approve');
     }
 }
-

--- a/src/ExportBatch.php
+++ b/src/ExportBatch.php
@@ -34,3 +34,4 @@ class ExportBatch extends Resource
         return $this->post($id, 'approve');
     }
 }
+

--- a/src/ExportBatch.php
+++ b/src/ExportBatch.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vindi;
+
+/**
+ * Class Invoice
+ *
+ * @package Vindi
+ */
+class ExportBatch extends Resource
+{
+    /**
+     * The endpoint that will hit the API.
+     *
+     * @return string
+     */
+    public function endpoint()
+    {
+        return 'export_batches';
+    }
+
+    /**
+     *  Make a POST request to invoices/{id}/retry
+     *
+     * @param  int $id The resource's id.
+     *
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Vindi\Exceptions\RateLimitException
+     * @throws \Vindi\Exceptions\RequestException
+     */
+    public function approve($id)
+    {
+        return $this->post($id, 'approve');
+    }
+}

--- a/src/ExportBatch.php
+++ b/src/ExportBatch.php
@@ -3,7 +3,7 @@
 namespace Vindi;
 
 /**
- * Class Invoice
+ * Class ExportBatch
  *
  * @package Vindi
  */
@@ -20,7 +20,7 @@ class ExportBatch extends Resource
     }
 
     /**
-     *  Make a POST request to invoices/{id}/retry
+     *  Make a POST request to export_batches/{id}/approve
      *
      * @param  int $id The resource's id.
      *

--- a/tests/ExportBatchTest.php
+++ b/tests/ExportBatchTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Vindi\Test;
+
+use Vindi\ExportBatch;
+use Vindi\ApiRequester;
+
+class ExportBatchTest extends ResourceTest
+{
+    public function setUp()
+    {
+        $this->resource = $this->getMockForAbstractClass(ExportBatch::class);
+        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+    }
+
+    /** @test */
+    public function it_should_have_an_endpoint()
+    {
+        $this->assertSame($this->resource->endpoint(), 'export_batches');
+    }
+
+    /** @test */
+    public function it_should_approve_an_export_batch()
+    {
+        $stdClass = new stdClass;
+
+        $this->resource->apiRequester->method('request')->willReturn($stdClass);
+
+        $response = $this->resource->approve(1);
+
+        $this->assertSame($response, $stdClass);
+    }
+}
+}

--- a/tests/ExportBatchTest.php
+++ b/tests/ExportBatchTest.php
@@ -31,4 +31,3 @@ class ExportBatchTest extends ResourceTest
         $this->assertSame($response, $stdClass);
     }
 }
-}

--- a/tests/ExportBatchTest.php
+++ b/tests/ExportBatchTest.php
@@ -31,3 +31,4 @@ class ExportBatchTest extends ResourceTest
         $this->assertSame($response, $stdClass);
     }
 }
+

--- a/tests/ExportBatchTest.php
+++ b/tests/ExportBatchTest.php
@@ -2,6 +2,7 @@
 
 namespace Vindi\Test;
 
+use stdClass;
 use Vindi\ExportBatch;
 use Vindi\ApiRequester;
 


### PR DESCRIPTION
## Motivação
Recentemente, a API recebeu uma nova endpoint para a exportação de arquivos de remessa.

## Solução Proposta
Estou adicionando o arquivo `ExportBatch.php` para manter a SDK atualizada.

## Como testar

Fiz a criação de um cliente, de uma fatura utilizando o boleto online, um lote de exportação e em seguida o aprovei.
 
```php
<?php
$customerService = new Vindi\Customer($arguments);
$billService = new Vindi\Bill($arguments);
$exportbatchService = new Vindi\ExportBatch($arguments);
$cliente = $customerService->create([
  'name' => 'teste de remessa'
]);

echo $cliente->id.PHP_EOL;

$bill = $billService->create([
  'customer_id' => $cliente->id,
  'payment_method_code' => 'bank_slip',
  'bill_items' => [
      [
        'product_id' => 843,
        'amount' => 100
      ]
    ]
]);

echo $bill->id.PHP_EOL;

$loteExportacao = $exportbatchService->create([
  'payment_method_code' => 'bank_slip'
]);

$loteExportacao = $exportbatchService->approve($loteExportacao->id);
echo $loteExportacao->url.PHP_EOL;
```

Resultado:

![image](https://user-images.githubusercontent.com/50752933/64119609-a0d73380-cd70-11e9-9e27-4b95fb4f79b7.png)
