### PR TITLE
Adiciona endpoint para listar product items por assinatura

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes will be documented in this file.
 
+## 1.2.2 - 01/11/2019
+- Add export batches endpoint
+- Add usages by period endpoint
+- Add product items by subscription endpoint
+
 ## 1.2.1 - 10/05/2019
 - Add the required parameter for partial refund
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes will be documented in this file.
 
-## 1.2.2 - 01/11/2019
+## 1.2.2 - 14/10/2020
 - Add export batches endpoint
 - Add usages by period endpoint
 - Add product items by subscription endpoint

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -50,6 +50,21 @@ class Subscription extends Resource
     }
 
     /**
+     * Make a GET request to subscriptions/{id}/product_items.
+     *
+     * @param int $id The resource's id.
+     *
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Vindi\Exceptions\RateLimitException
+     * @throws \Vindi\Exceptions\RequestException
+     */
+    public function product_items($id)
+    {
+        return $this->get($id, 'product_items');
+    }
+
+    /**
      * Make a POST request to subscriptions/{id}/renew.
      *
      * @param int $id The resource's id.

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -45,4 +45,13 @@ class SubscriptionTest extends ResourceTest
         $response = $this->resource->renew(1);
         $this->assertSame($response, $stdClass);
     }
+
+    /** @test */
+    public function it_should_return_product_items_from_a_subscription()
+    {
+        $stdClass = new stdClass;
+        $this->resource->apiRequester->method('request')->willReturn($stdClass);
+        $response = $this->resource->product_items(1);
+        $this->assertSame($response, $stdClass);
+    }
 }


### PR DESCRIPTION
Agora será possível listar itens de uma assinatura por ID.

Endpoint da documentação da API:
https://vindi.github.io/api-docs/dist/#/subscriptions/getV1SubscriptionsIdProductItems