### PR TITLE
Adiciona endpoint de registros de utilização por período

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -20,6 +20,21 @@ class Period extends Resource
     }
 
     /**
+     * Make a GET request to periods/{id}/usages.
+     *
+     * @param int $id The resource's id.
+     *
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Vindi\Exceptions\RateLimitException
+     * @throws \Vindi\Exceptions\RequestException
+     */
+    public function usages($id)
+    {
+        return $this->get($id, 'usages');
+    }
+
+    /**
      * Make a POST request to periods/{id}/bill.
      *
      * @param int $id The resource's id.

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -31,4 +31,16 @@ class PeriodTest extends ResourceTest
 
         $this->assertSame($response, $stdClass);
     }
+
+    /** @test */
+    public function it_should_return_usages_from_a_period()
+    {
+        $stdClass = new stdClass;
+
+        $this->resource->apiRequester->method('request')->willReturn($stdClass);
+
+        $response = $this->resource->usages(1);
+
+        $this->assertSame($response, $stdClass);
+    }
 }


### PR DESCRIPTION
Agora será possível listar registros de utilização por período.

Endpoint da documentação da API;
https://vindi.github.io/api-docs/dist/#/periods/getV1PeriodsIdUsages