### PR TITLE
Remove restrição de uso de métodos em camelCase.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "code-style": "./vendor/bin/phpcs --standard=PSR2 src/"
+        "code-style": "./vendor/bin/phpcs --standard=PSR2 --exclude=PSR1.Methods.CamelCapsMethodName src/"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
## O que mudou
Removida a necessidade de uso de métodos em CamelCase na configuração do PHP CS.

## Motivação
O método `product_items` da classe `Subscription` não respeita essa regra. 

Em toda execução de `composer code-style` o erro é notificado. Build do Travis CI também com falha devido essa configuração. 

![Screenshot from 2020-12-06 13-59-43](https://user-images.githubusercontent.com/1633216/101287339-76bfbd00-37ce-11eb-99fb-1dfe5cb05220.png)

## Solução proposta
Considerando que o método `Subscription.product_items` faz parte da API pública do SDK, renomeá-lo para respeitar a regra de camelCase não é uma alternativa uma vez que pode causar erros nas integração que já fazem uso desse método. 

Sendo assim, considero a melhor alternativa desabilitar essa restrição para as versão 1.x e ajustar a assinatura do método em versão futuras 2.x.

## Como testar
`composer code-style`