### PR TITLE
Atualiza Guzzle para versão 7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Este pacote consiste em um SDK em PHP para a [API de Recorrência][link-introducao-api] da [Vindi][link-vindi].
 
 # Requisitos
-- PHP versão **5.6.x** ou superior.
+- PHP versão **7.2.x** ou superior.
 - cURL habilitado para o PHP.
 - Certificado SSL.
 - Conta ativa na [Vindi](https://www.vindi.com.br "Vindi").

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "php": ">=7.2.5",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*",
+        "phpunit/phpunit": "8.*",
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "3.*"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/Bill.php
+++ b/src/Bill.php
@@ -14,7 +14,7 @@ class Bill extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'bills';
     }

--- a/src/BillItem.php
+++ b/src/BillItem.php
@@ -14,7 +14,7 @@ class BillItem extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'bill_items';
     }

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -14,7 +14,7 @@ class Charge extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'charges';
     }

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -14,7 +14,7 @@ class Customer extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'customers';
     }

--- a/src/Discount.php
+++ b/src/Discount.php
@@ -14,7 +14,7 @@ class Discount extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'discounts';
     }

--- a/src/ExportBatch.php
+++ b/src/ExportBatch.php
@@ -14,7 +14,7 @@ class ExportBatch extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'export_batches';
     }

--- a/src/ImportBatch.php
+++ b/src/ImportBatch.php
@@ -14,7 +14,7 @@ class ImportBatch extends Resource
      *
      * @return string
      */
-    public function endPoint()
+    public function endPoint(): string
     {
         return 'import_batches';
     }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -14,7 +14,7 @@ class Invoice extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'invoices';
     }

--- a/src/Issue.php
+++ b/src/Issue.php
@@ -14,7 +14,7 @@ class Issue extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'issues';
     }

--- a/src/Merchant.php
+++ b/src/Merchant.php
@@ -14,7 +14,7 @@ class Merchant extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'merchant';
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -14,7 +14,7 @@ class Message extends Resource
      *
      * @return string
      */
-    public function endPoint()
+    public function endPoint(): string
     {
         return 'messages';
     }

--- a/src/Movement.php
+++ b/src/Movement.php
@@ -14,7 +14,7 @@ class Movement extends Resource
      *
      * @return string
      */
-    public function endPoint()
+    public function endPoint(): string
     {
         return 'movements';
     }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -14,7 +14,7 @@ class Notification extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'notifications';
     }

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -14,7 +14,7 @@ class PaymentMethod extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'payment_methods';
     }

--- a/src/PaymentProfile.php
+++ b/src/PaymentProfile.php
@@ -14,7 +14,7 @@ class PaymentProfile extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'payment_profiles';
     }

--- a/src/Period.php
+++ b/src/Period.php
@@ -14,7 +14,7 @@ class Period extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'periods';
     }

--- a/src/Plan.php
+++ b/src/Plan.php
@@ -14,7 +14,7 @@ class Plan extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'plans';
     }

--- a/src/Product.php
+++ b/src/Product.php
@@ -14,7 +14,7 @@ class Product extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'products';
     }

--- a/src/ProductItem.php
+++ b/src/ProductItem.php
@@ -14,7 +14,7 @@ class ProductItem extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'product_items';
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -36,7 +36,7 @@ abstract class Resource
      *
      * @return string
      */
-    abstract public function endpoint();
+    abstract public function endpoint(): string;
 
     /**
      * Build url that will hit the API.

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -14,7 +14,7 @@ class Subscription extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'subscriptions';
     }

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -14,7 +14,7 @@ class Transaction extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'transactions';
     }

--- a/src/Usage.php
+++ b/src/Usage.php
@@ -14,7 +14,7 @@ class Usage extends Resource
      *
      * @return string
      */
-    public function endpoint()
+    public function endpoint(): string
     {
         return 'usages';
     }

--- a/tests/ApiRequesterTest.php
+++ b/tests/ApiRequesterTest.php
@@ -11,9 +11,10 @@ use Vindi\Exceptions\RequestException;
 use Vindi\Exceptions\ValidationException;
 use Vindi\Http\Client;
 use Vindi\ApiRequester;
+use PHPUnit\Framework\TestCase;
 use function GuzzleHttp\json_encode;
 
-class ApiRequesterTest extends \PHPUnit_Framework_TestCase
+class ApiRequesterTest extends TestCase
 {
     /**
      * @var \Vindi\ApiRequester;
@@ -25,13 +26,13 @@ class ApiRequesterTest extends \PHPUnit_Framework_TestCase
      */
     private $jsonError = '{"errors": [{"id": "id", "parameter": "parameter", "message": "message"}]}';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->apiRequester = new ApiRequester;
-        $this->apiRequester->client = $this->getMock(Client::class);
+        $this->apiRequester->client = $this->getMockBuilder(Client::class)->getMock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->apiRequester = null;
     }
@@ -50,7 +51,7 @@ class ApiRequesterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_throw_a_request_error()
     {
-        $this->setExpectedException(RequestException::class);
+        $this->expectException(RequestException::class);
         $response = new Response(401, [], $this->jsonError);
         $this->apiRequester->client->method('request')->willReturn($response);
 
@@ -60,7 +61,7 @@ class ApiRequesterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_throw_a_validation_error()
     {
-        $this->setExpectedException(ValidationException::class);
+        $this->expectException(ValidationException::class);
         $response = new Response(422, [], $this->jsonError);
         $this->apiRequester->client->method('request')->willReturn($response);
 
@@ -70,7 +71,7 @@ class ApiRequesterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_throw_a_rate_limit_exception()
     {
-        $this->setExpectedException(RateLimitException::class);
+        $this->expectException(RateLimitException::class);
         $response = new Response(429, ['Rate-Limit-Remaining' => 0], $this->jsonError);
         $this->apiRequester->client->method('request')->willReturn($response);
 
@@ -80,7 +81,7 @@ class ApiRequesterTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_catch_a_client_exception()
     {
-        $this->setExpectedException(RequestException::class);
+        $this->expectException(RequestException::class);
 
         $request = new Request('GET', 'test');
         $response = new Response(500, [], $this->jsonError);

--- a/tests/BillItemTest.php
+++ b/tests/BillItemTest.php
@@ -8,10 +8,10 @@ use Vindi\BillItem;
 
 class BillItemTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(BillItem::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/BillTest.php
+++ b/tests/BillTest.php
@@ -8,10 +8,10 @@ use Vindi\Bill;
 
 class BillTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Bill::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/ChargeTest.php
+++ b/tests/ChargeTest.php
@@ -8,10 +8,10 @@ use Vindi\Charge;
 
 class ChargeTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Charge::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -8,10 +8,10 @@ use Vindi\Customer;
 
 class CustomerTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Customer::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/DiscountTest.php
+++ b/tests/DiscountTest.php
@@ -7,10 +7,10 @@ use Vindi\Discount;
 
 class DiscountTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Discount::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/Exceptions/RateLimitExceptionTest.php
+++ b/tests/Exceptions/RateLimitExceptionTest.php
@@ -4,8 +4,9 @@ namespace Vindi\Test\Exceptions;
 
 use GuzzleHttp\Psr7\Response;
 use Vindi\Exceptions\RateLimitException;
+use PHPUnit\Framework\TestCase;
 
-class RateLimitExceptionTest extends \PHPUnit_Framework_TestCase
+class RateLimitExceptionTest extends TestCase
 {
     /** @test */
     public function it_should_access_exception_getters()

--- a/tests/Exceptions/RequestExceptionTest.php
+++ b/tests/Exceptions/RequestExceptionTest.php
@@ -4,8 +4,9 @@ namespace Vindi\Test\Exceptions;
 
 use GuzzleHttp\Psr7\Response;
 use Vindi\Exceptions\RequestException;
+use PHPUnit\Framework\TestCase;
 
-class RequestExceptionTest extends \PHPUnit_Framework_TestCase
+class RequestExceptionTest extends TestCase
 {
     /** @test */
     public function it_should_access_exception_getters()

--- a/tests/Exceptions/ValidationExceptionTest.php
+++ b/tests/Exceptions/ValidationExceptionTest.php
@@ -3,8 +3,9 @@
 namespace Vindi\Test\Exceptions;
 
 use Vindi\Exceptions\ValidationException;
+use PHPUnit\Framework\TestCase;
 
-class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
+class ValidationExceptionTest extends TestCase
 {
     /** @test */
     public function it_should_access_exception_getters()

--- a/tests/ExportBatchTest.php
+++ b/tests/ExportBatchTest.php
@@ -8,10 +8,10 @@ use Vindi\ApiRequester;
 
 class ExportBatchTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(ExportBatch::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -1,20 +1,21 @@
 <?php namespace Vindi\Test\Http;
 
 use Vindi\Http\Client;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var \Vindi\Http\Client
      */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new Client();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->client = null;
     }

--- a/tests/ImportBatchTest.php
+++ b/tests/ImportBatchTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class ImportBatchTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(ImportBatch::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -8,10 +8,10 @@ use Vindi\Invoice;
 
 class InvoiceTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Invoice::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/IssueTest.php
+++ b/tests/IssueTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class issueTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Issue::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/MerchantTest.php
+++ b/tests/MerchantTest.php
@@ -7,10 +7,10 @@ use Vindi\Merchant;
 
 class MerchantTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Merchant::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class MessageTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Message::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/MovementTest.php
+++ b/tests/MovementTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class MovementTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Movement::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -7,10 +7,10 @@ use Vindi\Notification;
 
 class NotificationTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Notification::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -7,10 +7,10 @@ use Vindi\PaymentMethod;
 
 class PaymentMethodTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(PaymentMethod::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/PaymentProfileTest.php
+++ b/tests/PaymentProfileTest.php
@@ -8,10 +8,10 @@ use stdClass;
 
 class PaymentProfileTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(PaymentProfile::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -8,10 +8,10 @@ use Vindi\Period;
 
 class PeriodTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Period::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/PlanTest.php
+++ b/tests/PlanTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class PlanTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Plan::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/ProductItemTest.php
+++ b/tests/ProductItemTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class ProductItemTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(ProductItem::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class ProductTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Product::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -6,21 +6,22 @@ use stdClass;
 use Vindi\ApiRequester;
 use Vindi\Resource;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class ResourceTest extends \PHPUnit_Framework_TestCase
+class ResourceTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     protected $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Resource::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->resource = null;
     }

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -8,10 +8,10 @@ use Vindi\Subscription;
 
 class SubscriptionTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Subscription::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class TransactionTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Transaction::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/UsageTest.php
+++ b/tests/UsageTest.php
@@ -7,10 +7,10 @@ use Vindi\ApiRequester;
 
 class UsageTest extends ResourceTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = $this->getMockForAbstractClass(Usage::class);
-        $this->resource->apiRequester = $this->getMock(ApiRequester::class);
+        $this->resource->apiRequester = $this->getMockBuilder(ApiRequester::class)->getMock();
     }
 
     /** @test */

--- a/tests/VindiTest.php
+++ b/tests/VindiTest.php
@@ -3,8 +3,9 @@
 namespace Vindi\Test;
 
 use Vindi\Vindi;
+use PHPUnit\Framework\TestCase;
 
-class VindiTest extends \PHPUnit_Framework_TestCase
+class VindiTest extends TestCase
 {
 
     /** @test */

--- a/tests/WebhookHandlerTest.php
+++ b/tests/WebhookHandlerTest.php
@@ -4,20 +4,21 @@ namespace Vindi\Test;
 
 use Vindi\Exceptions\WebhookHandleException;
 use Vindi\WebhookHandler;
+use PHPUnit\Framework\TestCase;
 
-class WebhookHandlerTest extends \PHPUnit_Framework_TestCase
+class WebhookHandlerTest extends TestCase
 {
     /**
      * @var \Vindi\WebhookHandler
      */
     protected $webhookHandler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->webhookHandler = new WebhookHandler;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->webhookHandler = null;
     }
@@ -45,7 +46,7 @@ class WebhookHandlerTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_should_refuse_an_empty_webhook()
     {
-        $this->setExpectedException(WebhookHandleException::class, 'Empty post body!');
+        $this->expectException(WebhookHandleException::class, 'Empty post body!');
         $this->webhookHandler->handle();
     }
 
@@ -54,7 +55,7 @@ class WebhookHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->webhookHandler->file = dirname(__FILE__) . '/data/webhook-invalid.txt';
 
-        $this->setExpectedException(WebhookHandleException::class, 'Unable to decode JSON from post body!');
+        $this->expectException(WebhookHandleException::class, 'Unable to decode JSON from post body!');
         $this->webhookHandler->handle();
     }
 }


### PR DESCRIPTION
## O que mudou

Pacotes foram atualizados. 
  - Guzzle para versão 7. 
  - PHP para versão 7.2.
  - PHPUnit para versão 8.

## Motivação
Diversos pacotes já usam o Guzzle na versão 7 o que torna incompatível o uso do SDK VINDI junto com eses. Em particular, a atualização para [Laravel 8](https://laravel.com/docs/8.x/upgrade#updating-dependencies) requer Guzzle na versão 7.

## Solução proposta
Atualização dos pacotes: Guzzle 7 requer PHP 7.2 o qual requer o PHPUnit na versão 8.

Sendo assim, os testes unitários também foram adpatados para versão 8 do PHPUnit. 

De forma geral as atualizações foram somente as necessárias para upgrade da versão do PHPUnit. 

Exceto, a alteração na assinatura do método `endpoint()` em `Resource` que necessitou ter o tipo de retorno informado na assinatura para preservar o teste `it_should_have_an_endpoint` em `ResourceTest` o qual testa o retorno como string. 


## Como testar
Executar os testes: `composer test`.
