### PR TITLE
Fix PHP8.1 deprecation messages.

### DIFF
--- a/src/ApiRequester.php
+++ b/src/ApiRequester.php
@@ -78,8 +78,9 @@ class ApiRequester
         $data = $decoded;
 
         if (!empty($decoded)) {
-            reset($decoded);
-            $data = current($decoded); // get first attribute from array, e.g.: subscription, subscriptions, errors.
+            $decoded_array = (array) $decoded;
+            reset($decoded_array);
+            $data = (object) current($decoded_array); // get first attribute from array, e.g.: subscription, subscriptions, errors.
         }
 
         $this->checkRateLimit($response)


### PR DESCRIPTION
## O que mudou
Fixes PHP8.1 deprecation messages.

## Motivação
Prevent logs filling up with deprecation messages.

## Solução proposta
Cast variables to arrays before using current and reset.

## Como testar
Switch dev env to PHP8.1 and check logs.
