### PR TITLE
Fix endpoint product_items na assinatura

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -59,9 +59,9 @@ class Subscription extends Resource
      * @throws \Vindi\Exceptions\RateLimitException
      * @throws \Vindi\Exceptions\RequestException
      */
-    public function product_items($id)
+    public function product_items($id, array $params = [])
     {
-        return $this->get($id, 'product_items');
+        return $this->apiRequester->request('GET', $this->url($id, 'product_items'), ['query' => $params]);
     }
 
     /**


### PR DESCRIPTION
## O que mudou
Assinatura do método de `product_items()` no recurso `Subscription` alterada de acordo com o que é mostrado na documentação documentação. Não há quebra no uso atual do método.

## Motivação
Para tornar possível a buscar com paginação dos items de 1 assinatura conforme documentação. Em https://vindi.github.io/api-docs/dist/#/subscriptions/getV1SubscriptionsIdProductItems
![Screenshot from 2023-03-15 11-29-04](https://user-images.githubusercontent.com/1633216/225342441-574ae8a4-956f-4c6f-8640-6f6148259769.png)


## Solução proposta
Método `product_items()` recebe parâmetro opcional para aplicação de paginação, conforme assinatura do método `all()` de `Resource`

## Como testar
Testes unitários. Ou utilizar rota em `/v1/subscriptions/{id}/product_items` com paginação.